### PR TITLE
Add compatibility with GNOME 40

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -88,17 +88,16 @@ function enable() {
 	indicator_button.actor.add_actor(icon);
 
 	// Switcher item
-	switcher = new PopupMenu.PopupSwitchMenuItem('');
+	switcher = new PopupMenu.PopupSwitchMenuItem("", settings.get_boolean("enabled"));
 	switcher.connect("toggled", _onToggle);
-	switcher.setToggleState(settings.get_boolean("enabled"));
 	_onToggle();
 	indicator_button.menu.addMenuItem(switcher);
 	
 	// Slider item
-	let sliderItem = new PopupMenu.PopupMenuItem('');
+	let sliderItem = new PopupMenu.PopupMenuItem("");
 	slider = new Slider.Slider(Math.log(period) / max_pow);
-	slider.connect("value-changed", _onSliderChanged);
-	sliderItem.actor.add(slider.actor, {expand: true});
+	slider.connect("notify::value", _onSliderChanged);
+    sliderItem.add_child(slider);
 	indicator_button.menu.addMenuItem(sliderItem);
 
 	// Finally
@@ -109,8 +108,6 @@ function enable() {
 	settings.connect('changed::period', _onSettingsChanged);
 	settings.connect('changed::max-interval', _onSettingsChanged);
 	settings.connect('changed::command', _onSettingsChanged);
-	
-	// TODO: remove
 }
 
 // Function is called when extension is disabled + screen is locked
@@ -123,6 +120,6 @@ function disable() {
   Left in case I decide to add a settings button to the panel menu in the future.
 
   function _openPrefs() {
-      Util.spawn(["gnome-shell-extension-prefs", Extension.uuid]);
+  Util.spawn(["gnome-shell-extension-prefs", Extension.uuid]);
   }
 */

--- a/metadata.json
+++ b/metadata.json
@@ -1,8 +1,9 @@
 {
-	"shell-version": ["3.26.2"],
+	"shell-version": ["40"],
 	"uuid": "beep-timer@rusins.github.com",
 	"name": "Beep Timer",
 	"description": "Makes a sound play once every X seconds.",
 	"settings-schema": "org.gnome.shell.extensions.beep-timer",
-	"url": "https://github.com/rusins/beep-timer"
+	"url": "https://github.com/rusins/beep-timer",
+	"version" : 2
 }

--- a/prefs.js
+++ b/prefs.js
@@ -25,6 +25,5 @@ function buildPrefsWidget() {
 	settings.bind("command", builder.get_object("field_command"), "text", Gio.SettingsBindFlags.DEFAULT);
 	settings.bind("eager", builder.get_object("field_eager"), "active", Gio.SettingsBindFlags.DEFAULT);
 
-	frame.show_all();
 	return frame;
 }

--- a/prefs.xml
+++ b/prefs.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.2 -->
 <interface>
-  <requires lib="gtk+" version="3.20"/>
+  <requires lib="gtk" version="4.0"/>
   <object class="GtkAdjustment" id="adjustment_max-interval">
     <property name="upper">10000</property>
     <property name="step_increment">1</property>
@@ -14,156 +13,73 @@
     <property name="page_increment">10</property>
   </object>
   <object class="GtkBox" id="prefs_widget">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="margin_left">18</property>
-    <property name="margin_right">18</property>
+    <property name="can_focus">0</property>
+    <property name="margin-start">18</property>
+    <property name="margin-end">18</property>
     <property name="margin_top">18</property>
     <property name="margin_bottom">18</property>
     <property name="orientation">vertical</property>
     <property name="spacing">10</property>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can_focus">0</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">0</property>
             <property name="label" translatable="yes">Period / Interval (in seconds)</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkSpinButton" id="field_period">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
             <property name="adjustment">adjustment_period</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">0</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can_focus">0</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">0</property>
             <property name="label" translatable="yes">Maximum interval (in minutes)</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
           <object class="GtkSpinButton" id="field_max-interval">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
             <property name="adjustment">adjustment_max-interval</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">1</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can_focus">0</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">0</property>
             <property name="label" translatable="yes">Command to execute</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkEntry" id="field_command">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
+          <object class="GtkEntry" id="field_command"/>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">2</property>
-      </packing>
     </child>
     <child>
       <object class="GtkBox">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can_focus">0</property>
         <child>
           <object class="GtkLabel">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">0</property>
             <property name="label" translatable="yes">Should command be executed when timer
  is first enabled</property>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkSwitch" id="field_eager">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">1</property>
-          </packing>
+          <object class="GtkSwitch" id="field_eager"/>
         </child>
       </object>
-      <packing>
-        <property name="expand">False</property>
-        <property name="fill">True</property>
-        <property name="position">3</property>
-      </packing>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
I was reading about how to migrate an extension from GNOME 3.x to GNOME 40 and I started to make changes following [the documentation](https://gjs.guide/extensions/upgrading/gnome-shell-40.html#show-all-and-destroy).

I can't still make the extension run, I have this error:

> Invalid value 'undefined' for property state in object initializer.

